### PR TITLE
Quote arguments with "&" character on Windows

### DIFF
--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -97,6 +97,15 @@ def launch_gateway(conf=None, popen_kwargs=None):
                 popen_kwargs['preexec_fn'] = preexec_func
                 proc = Popen(command, **popen_kwargs)
             else:
+                # If an argument contains an ampersand (e.g. a URI to a cloud resource),
+                # we need to apply a double quoting mechanism to correctly pass the
+                # value through the submit shell scripts.
+                command = [
+                    '"""' + s.replace("&", "^^^&") + '"""' 
+                    if '&' in s else s
+                    for s in command
+                ]
+                
                 # preexec_fn not supported on Windows
                 proc = Popen(command, **popen_kwargs)
 


### PR DESCRIPTION
This fixes issue #35124. Note that it is quite unlikely that this issue would be mitigated or fixed in the Python standard library itself code due to the history of "subprocess.list2cmdline" (see https://bugs.python.org/issue8972 which was created in 2010).

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?

This fixes support for the "&" character appearing in Spark configuration values (common in cloud resource URIs).

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

If an "&" character appears in a configuration value, the Windows submit scripts do not work correctly, interpreting the character as the beginning of a new command rather as part of an argument.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?

No.

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?

This was tested manually, providing a configuration value with a "&" character in it.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
